### PR TITLE
Normalize CI/CD workflows

### DIFF
--- a/.github/workflows/approve-dependabot.yml
+++ b/.github/workflows/approve-dependabot.yml
@@ -1,16 +1,17 @@
-# SPDX-FileCopyrightText: 2022 Comcast Cable Communications Management, LLC
+# SPDX-FileCopyrightText: 2023 Comcast Cable Communications Management, LLC
 # SPDX-License-Identifier: Apache-2.0
 ---
 name: 'Dependabot auto approval'
 
 on:
-  pull_request_target
+  pull_request_target:
 
 permissions:
   pull-requests: write
   contents: write
 
 jobs:
-  package:
-    uses: xmidt-org/shared-go/.github/workflows/approve-dependabot.yml@f0ba95798ab73202b3f2812ea0209db07d99c6e8 # v4.9.41
+  approve:
+    # yamllint disable-line
+    uses: xmidt-org/shared-go/.github/workflows/approve-dependabot.yml@aff0471aa7e2f96ddb059beb178f63747a7cc57e # v4.9.41
     secrets: inherit

--- a/.github/workflows/approve-dependabot.yml
+++ b/.github/workflows/approve-dependabot.yml
@@ -5,11 +5,12 @@ name: 'Dependabot auto approval'
 
 on:
   pull_request_target
+
 permissions:
   pull-requests: write
   contents: write
 
 jobs:
   package:
-    uses: xmidt-org/.github/.github/workflows/dependabot-approver-template.yml@main
+    uses: xmidt-org/shared-go/.github/workflows/approve-dependabot.yml@f0ba95798ab73202b3f2812ea0209db07d99c6e8 # v4.9.41
     secrets: inherit

--- a/.github/workflows/auto-releaser.yml
+++ b/.github/workflows/auto-releaser.yml
@@ -1,14 +1,18 @@
 # SPDX-FileCopyrightText: 2024 Comcast Cable Communications Management, LLC
 # SPDX-License-Identifier: Apache-2.0
 ---
-name: 'Automatically relase patch versions.'
+name: 'Auto Release'
 
 on:
   schedule: # Run every day at 12:00 UTC
     - cron: '0 12 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   release:
-    uses: xmidt-org/shared-go/.github/workflows/auto-releaser.yml@4468342f575e09429c1b04637dcda065145846e4 # v4.9.40
+    # yamllint disable-line
+    uses: xmidt-org/shared-go/.github/workflows/auto-releaser.yml@aff0471aa7e2f96ddb059beb178f63747a7cc57e # v4.9.41
     secrets: inherit

--- a/.github/workflows/auto-releaser.yml
+++ b/.github/workflows/auto-releaser.yml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2024 Comcast Cable Communications Management, LLC
+# SPDX-License-Identifier: Apache-2.0
+---
+name: 'Automatically relase patch versions.'
+
+on:
+  schedule: # Run every day at 12:00 UTC
+    - cron: '0 12 * * *'
+  workflow_dispatch:
+
+jobs:
+  release:
+    uses: xmidt-org/shared-go/.github/workflows/auto-releaser.yml@4468342f575e09429c1b04637dcda065145846e4 # v4.9.40
+    secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ permissions:
 
 jobs:
   ci:
+    # yamllint disable-line
     uses: xmidt-org/shared-go/.github/workflows/ci.yml@aff0471aa7e2f96ddb059beb178f63747a7cc57e # v4.9.41
     with:
       release-type:   library

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,11 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  pull-requests: read
+  contents: write
+  packages: write
+
 jobs:
   ci:
     uses: xmidt-org/shared-go/.github/workflows/ci.yml@aff0471aa7e2f96ddb059beb178f63747a7cc57e # v4.9.41

--- a/.github/workflows/proj-xmidt-team.yml
+++ b/.github/workflows/proj-xmidt-team.yml
@@ -11,7 +11,12 @@ on:
     types:
       - opened
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   package:
-    uses: xmidt-org/.github/.github/workflows/proj-template.yml@proj-v1
+    uses: xmidt-org/.github/.github/workflows/proj-template.yml@2499ba298ccd297c941bff75404de947c80d8346 # proj-v1
     secrets: inherit

--- a/.github/workflows/proj.yml
+++ b/.github/workflows/proj.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Comcast Cable Communications Management, LLC
+# SPDX-FileCopyrightText: 2023 Comcast Cable Communications Management, LLC
 # SPDX-License-Identifier: Apache-2.0
 ---
 name: 'PROJ: xmidt-team'
@@ -17,6 +17,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  package:
-    uses: xmidt-org/.github/.github/workflows/proj-template.yml@2499ba298ccd297c941bff75404de947c80d8346 # proj-v1
+  proj:
+    # yamllint disable-line
+    uses: xmidt-org/shared-go/.github/workflows/proj.yml@aff0471aa7e2f96ddb059beb178f63747a7cc57e # v4.9.41
     secrets: inherit


### PR DESCRIPTION
## Summary

This PR normalizes the CI/CD workflows to match the xmidt-org Ideal State as outlined in issue #59.

## Changes

- Added top-level `permissions` block to `ci.yml` with `pull-requests: read`, `contents: write`, `packages: write`
- Created `auto-releaser.yml` workflow
- Renamed `dependabot-approver.yml` to `approve-dependabot.yml` and updated workflow reference to use `xmidt-org/shared-go/.github/workflows/approve-dependabot.yml`
- Updated `proj-xmidt-team.yml` to reference the correct workflow path and added top-level `permissions` block with `contents: read`, `issues: write`, `pull-requests: write`
- Pinned all workflow references to full commit SHAs with version comments

Fixes #59